### PR TITLE
[#1280] fix: displaying the correct date in any time zone

### DIFF
--- a/src/components/molecules/Calendar/Content.tsx
+++ b/src/components/molecules/Calendar/Content.tsx
@@ -1,7 +1,12 @@
 import { getWeekDays } from '@/utils/get-week-days';
+import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import * as Popover from '@radix-ui/react-popover';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
+import { useCalendarContext } from './Root';
+import { SelectMonths } from './SelectMonths';
+import { SelectYears } from './SelectYears';
 import {
   CalendarActions,
   CalendarDay,
@@ -10,11 +15,6 @@ import {
   LeftCalendarAction,
   RightCalendarAction,
 } from './styles';
-import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
-import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import { useCalendarContext } from './Root';
-import { SelectMonths } from './SelectMonths';
-import { SelectYears } from './SelectYears';
 
 interface CalendarWeek {
   week: number;
@@ -135,7 +135,7 @@ export function Content({ onSelected, selected, ...props }: ContentProps) {
                 {days.map(({ date, disabled }) => (
                   <td key={date.toString()}>
                     <CalendarDay
-                      pressed={date.isSame(dayjs(selected))}
+                      pressed={date.isSame(dayjs(selected), 'day')}
                       onPressedChange={() =>
                         onSelected && onSelected(date.toDate())
                       }

--- a/src/components/molecules/Calendar/Root.tsx
+++ b/src/components/molecules/Calendar/Root.tsx
@@ -26,7 +26,7 @@ export function Root({ children, ...props }: RootProps) {
     });
 
     return Array.from(Array(12).keys()).map(number => {
-      const monthName = formatter.format(new Date(Date.UTC(2021, number + 1)));
+      const monthName = formatter.format(new Date(2021, number));
       return monthName
         .substring(0, 1)
         .toUpperCase()

--- a/src/components/molecules/FormRegister/FormRegisterFields/index.tsx
+++ b/src/components/molecules/FormRegister/FormRegisterFields/index.tsx
@@ -1,14 +1,17 @@
 import { Eye } from '@/components/atoms/Eye';
 import { InfoTooltip } from '@/components/atoms/InfoTooltip';
-import { DatePickerContainer, WrapperInput } from './styles';
-import { InputForm } from '../../../atoms/InputForm';
-import { Calendar } from '../../Calendar';
+import { ValuesFormType } from '@/utils/registerSchema';
 import { Field, useFormikContext } from 'formik';
 import { useState } from 'react';
-import { ValuesFormType } from '@/utils/registerSchema';
+import { InputForm } from '../../../atoms/InputForm';
+import { Calendar } from '../../Calendar';
+import { DatePickerContainer, WrapperInput } from './styles';
 
 import EventRoundedIcon from '@mui/icons-material/EventRounded';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
 
 export function FormRegisterFields() {
   const [showCalendar, setShowCalendar] = useState(false);
@@ -56,10 +59,7 @@ export function FormRegisterFields() {
         <Calendar.Content
           selected={formik.values.dateBirthday}
           onSelected={(date: Date) => {
-            formik.setValues({
-              ...formik.values,
-              dateBirthday: date,
-            });
+            formik.setFieldValue('dateBirthday', dayjs.utc(date));
             setShowCalendar(false);
           }}
           avoidCollisions={false}


### PR DESCRIPTION
- No formulário de cadastro, exibe corretamente a data selecionada pelo usuário em qualquer fuso horário.
Antes, dependendo do fuso horário do usuário, os meses não estavam aparecendo corretamente