### PR TITLE
fix: simplifica seleção de foto do perfil

### DIFF
--- a/src/components/atoms/EditPhotoModal/index.tsx
+++ b/src/components/atoms/EditPhotoModal/index.tsx
@@ -3,12 +3,9 @@ import {
   ButtonsContainer,
   EditPhotoContainer,
   StyledInfo,
-  StyledHR,
-  SaveButton,
   ActionButton,
   PhotoContainerActions,
   ModalCloseButton,
-  ModalCloseSavePhoto,
 } from './styled';
 import PhotoButton from '../PhotoButton';
 import ModalImageEditor from '../ModalImageEditor';
@@ -65,11 +62,15 @@ export default function EditPhotoModal({
   };
 
   const handleSavePhoto = (editedImage: string | null) => {
-    if (selectedPhoto && onAddPhoto) {
-      onAddPhoto(selectedPhoto);
-    }
+    const photo = editedImage ?? selectedPhoto;
+
     if (onImageEdit) {
-      onImageEdit(editedImage);
+      onImageEdit(photo);
+      return;
+    }
+
+    if (onAddPhoto) {
+      onAddPhoto(photo);
     }
   };
 
@@ -113,16 +114,6 @@ export default function EditPhotoModal({
         </ButtonsContainer>
       </PhotoContainerActions>
 
-      <StyledHR aria-hidden />
-
-      <ModalCloseSavePhoto asChild>
-        <SaveButton
-          disabled={!selectedPhoto}
-          onClick={() => handleSavePhoto(selectedPhoto)}
-        >
-          Salvar
-        </SaveButton>
-      </ModalCloseSavePhoto>
     </EditPhotoContainer>
   );
 }

--- a/src/components/atoms/EditPhotoModal/styled.ts
+++ b/src/components/atoms/EditPhotoModal/styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { Button } from '../Button';
 import { Modal } from '../Modal';
 
 export const EditPhotoContainer = styled(Modal.Content)`
@@ -32,17 +31,6 @@ export const ButtonsContainer = styled.div`
   width: 100%;
   display: flex;
   gap: 1rem;
-`;
-
-export const StyledHR = styled.div`
-  width: 100%;
-  height: 1px;
-  background-color: ${props => props.theme.colors.gray[700]};
-  margin-top: 0.25rem;
-`;
-
-export const SaveButton = styled(Button)`
-  margin-left: auto;
 `;
 
 export const ActionButton = styled.button`
@@ -84,11 +72,4 @@ export const ActionButton = styled.button`
 export const ModalCloseButton = styled(Modal.Close)`
   top: 1.5rem;
   right: 1.5rem;
-`;
-
-export const ModalCloseSavePhoto = styled(Modal.Close)`
-  position: static;
-  background-color: ${props => props.theme.colors.blue[800]};
-  color: ${props => props.theme.colors.white};
-  line-height: 0.7rem;
 `;

--- a/src/components/organisms/AccountPage/ProfileTab/FormFields/index.tsx
+++ b/src/components/organisms/AccountPage/ProfileTab/FormFields/index.tsx
@@ -23,6 +23,7 @@ import { useEffect, useState } from 'react';
 
 export function FormFields() {
   const [isMaxCharactersExceeded, setIsMaxCharactersExceeded] = useState(false);
+  const [isEditPhotoModalOpen, setIsEditPhotoModalOpen] = useState(false);
   const { mentor } = useAuthContext();
   const [specialties, setSpecialties] = useState<string[]>(
     mentor.data?.specialties ?? []
@@ -31,6 +32,7 @@ export function FormFields() {
 
   const handleImageEdit = (editedImage: string | null) => {
     formik.setFieldValue('profile', editedImage || '');
+    setIsEditPhotoModalOpen(false);
   };
 
   const selectedCount = specialties.length ?? mentor.data?.specialties;
@@ -80,7 +82,10 @@ export function FormFields() {
 
   return (
     <ContentContainer>
-      <Modal.Root>
+      <Modal.Root
+        open={isEditPhotoModalOpen}
+        onOpenChange={setIsEditPhotoModalOpen}
+      >
         <ButtonEditPhoto>
           <PhotoButton
             selectedPhoto={formik.values.profile ?? mentor.data?.profile}
@@ -105,6 +110,7 @@ export function FormFields() {
           selectedPhoto={formik.values.profile ?? mentor.data?.profile ?? ''}
           onAddPhoto={photo => {
             formik.setFieldValue('profile', photo);
+            setIsEditPhotoModalOpen(false);
           }}
           onImageEdit={handleImageEdit}
         />

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -7,6 +7,6 @@ const serverUrl = {
 };
 
 export const api = axios.create({
-  baseURL: serverUrl.development,
+  baseURL: serverUrl.developmentLocal,
   withCredentials: true,
 });


### PR DESCRIPTION
## Resumo
Corrige o fluxo de alteração da foto de perfil para evitar dois salvamentos no mesmo processo.

## Alterações
- Remove o botão “Salvar” do modal de seleção de foto.
- Atualiza a imagem diretamente na tela de perfil ao adicionar ou editar a foto.
- Fecha o modal automaticamente após a foto ser selecionada/editada.
- Mantém a persistência dos dados apenas no botão “Salvar” principal da aba Perfil.
